### PR TITLE
Treat month w/no day as interval including whole month

### DIFF
--- a/daterangeparser/parse_date_range.py
+++ b/daterangeparser/parse_date_range.py
@@ -84,16 +84,18 @@ def post_process(res):
     # We have a single date, not a range
     res['start'] = {}
     res['start']['day'] = res.end.day
-    if res['start']['day'] == '':
-      res['start']['day'] = 1
     res['start']['month'] = res.end.month
     if 'year' not in res.end:
       res['start']['year'] = today.year
     else:
       res['start']['year'] = res.end.year
-    
-    res['end'] = None
-    return res
+    if res['start']['day'] == '':
+      # special case - treat bare month as range
+      res['start']['day'] = 1
+      res['end']['day'] = calendar.monthrange(today.year, res.end.month)[1]
+    else:
+      res['end'] = None
+      return res
   
   # Sort out years
   if 'year' not in res.end:

--- a/daterangeparser/test.py
+++ b/daterangeparser/test.py
@@ -66,9 +66,13 @@ class WorkingParsingTest(unittest.TestCase):
             ("Thurs Nov 11th 1954", "11/11/1954", None),
 
             # Dates with no days
-            ("July", "01/07/XXXX", None),
+            ("July", "01/07/XXXX", "31/07/XXXX"),
             ("Feb to Nov", "01/02/XXXX", "30/11/XXXX"),
             ("Feb 2010 - Feb 2012", "01/02/2010", "29/02/2012")
+
+            # Bare year - doesn't work yet
+            #("2013", "01/01/2013", "31/12/2013"),
+            #("1995 - 2010", "01/01/1995", "31/12/2010"),
   ]
   
   def runTest(self):


### PR DESCRIPTION
When in English, one says "September" (especially in the context where a date range is expected),  he usually means the whole month, not a specific day of it. This patch implements this.

Same goes for a year (TODO).
