### PR TITLE
Use the start month if the end month doesn't exist

### DIFF
--- a/daterangeparser/parse_date_range.py
+++ b/daterangeparser/parse_date_range.py
@@ -248,6 +248,8 @@ def parse(text):
     return (start_datetime, None)
   else:
     try:
+      if "month" not in res.end:
+        res.end["month"] = res.start["month"]
       end_str = "%(day)s/%(month)s/%(year)s" % res.end
       end_datetime = datetime.datetime.strptime(end_str, "%d/%m/%Y")
     except ValueError:

--- a/daterangeparser/test.py
+++ b/daterangeparser/test.py
@@ -29,6 +29,7 @@ class WorkingParsingTest(unittest.TestCase):
             ("Tuesday 29 May - Sat 2 June 2012", "29/5/2012", "2/6/2012"),
             ("1-9 Jul", "1/7/XXXX", "9/7/XXXX"),
             ("Tuesday 19th June - Wednesday 20th June 2013", "19/6/2013", "20/6/2013"),
+            ("January 10th - 11th", "10/1/XXXX", "11/1/XXXX"),
             
             # Different separators
             ("14--16th May", "14/5/XXXX", "16/5/XXXX"),

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ Most date range formats that use specific dates (rather than 'tomorrow' or 'last
 Examples that are known to work include:
 
 - 27th-29th June 2010
+- January 10th - 11th
 - 30 May to 9th Aug
 - 3rd Jan 1980 -- 2nd Jan 2013
 - Wed 23 Jan -> Sat 16 February 2013


### PR DESCRIPTION
Hey,

Using strings like the one in the test I added, before a KeyError would be raised. Now, it uses the start date's month.